### PR TITLE
Cleanup Flatpak manifest

### DIFF
--- a/flatpak/design.chris_wood.IconBear.json
+++ b/flatpak/design.chris_wood.IconBear.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "design.chris_wood.IconBear",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.node18",
@@ -9,12 +9,11 @@
     ],
     "command" : "design.chris_wood.IconBear",
     "finish-args" : [
-        "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland",
-	"--filesystem=home:ro"
+        "--filesystem=home:ro"
     ],
     "build-options" : {
         "append-path" : "/usr/lib/sdk/typescript/bin:/usr/lib/sdk/node18/bin"
@@ -37,8 +36,8 @@
             "buildsystem" : "meson",
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "file:///home/chriswood/Projects"
+                    "type" : "dir",
+                    "path" : ".."
                 }
             ]
         }


### PR DESCRIPTION
Puts the manifest in a separate directory, removes the (afaik) unused network permission, uses the master runtime for development, points to a relative dir rather than a hard path. I *would* like to ask what the `--filesystem=home:ro` permission is used for.